### PR TITLE
Fixed install.sh shebang

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/bash
+#!/usr/bin/env bash
 
 # where to put the aura directory
 BASEDIR="$HOME/.config"


### PR DESCRIPTION
Some distributions place bash at different places - the old code for example won't work on Ubuntu Server. Using `env` is the preferred variant, since it starts shell regardless of where is it actually placed.